### PR TITLE
[BOJ] 2578, 20546

### DIFF
--- a/구현-시뮬레이션/20546_현지연.py
+++ b/구현-시뮬레이션/20546_현지연.py
@@ -1,0 +1,43 @@
+money = int(input())                        # 현금
+stock = list(map(int, input().split()))     # 주가
+
+junhyun_m, seongmin_m = money, money        # 현금
+junhyun_s, seongmin_s = 0, 0                # 주가
+
+increase_cnt = 0    # 전일 대비 상승 횟수
+decrease_cnt = 0    # 전일 대비 하락 횟수
+
+for i in range(14):
+    # 준현 전량 매수
+    junhyun_s += junhyun_m // stock[i]
+    junhyun_m -= (junhyun_m // stock[i]) * stock[i]
+    
+    # 성민
+    if i > 0:
+        if stock[i] > stock[i - 1]:
+            increase_cnt += 1
+            decrease_cnt = 0
+        elif stock[i] < stock[i - 1]:
+            decrease_cnt += 1
+            increase_cnt = 0
+        else:
+            increase_cnt = 0
+            decrease_cnt = 0
+    # 성민 전량 매도
+    if increase_cnt >= 3:
+        seongmin_m += seongmin_s * stock[i]
+        seongmin_s = 0
+    # 성민 전량 매수
+    if decrease_cnt >= 3:
+        seongmin_s += seongmin_m // stock[i]
+        seongmin_m -= (seongmin_m // stock[i]) * stock[i]
+
+junhyun_result = junhyun_m + (stock[13] * junhyun_s)    # 마지막 날 자산
+seongmin_result = seongmin_m + (stock[13] * seongmin_s)
+
+if junhyun_result < seongmin_result:
+    print("TIMING")
+elif junhyun_result > seongmin_result:
+    print("BNP")
+else:
+    print("SAMESAME")

--- a/구현-시뮬레이션/2578_현지연.py
+++ b/구현-시뮬레이션/2578_현지연.py
@@ -1,0 +1,41 @@
+from collections import defaultdict
+
+bingo = [0] * (26)  
+
+# 숫자 인덱스 위치에 빙고판 (i, j) 저장
+for i in range(5):
+    chulsoo = list(map(int, input().split()))   # 철수의 입력
+    for j in range(5):
+        bingo[chulsoo[j]] = (i, j)
+
+row_dic = defaultdict(list)     # 행 딕셔너리
+col_dict = defaultdict(list)    # 열 딕셔너리
+x_dict = defaultdict(list)      # 대각선 딕셔너리
+answer = 25
+
+for k in range(5):
+    mc = list(map(int, input().split()))    # 사회자의 입력
+    for t in range(5):
+        i, j = bingo[mc[t]]                 # 사회자가 부르는 수의 빙고판 i, j 위치
+        row_dic[i].append(j)                # 행 딕셔너리에 열 번호 추가
+        col_dict[j].append(i)               # 열 딕셔너리에 행 번호 추가
+        if i == j:                          # 오른쪽 대각선 추가
+            x_dict['right'].append(i)
+        if i + j == 4:                      # 왼쪽 대각선 추가
+            x_dict['left'].append(i)
+
+        cnt = 0                             # 빙고 선의 개수
+        for arr in row_dic.values():        # 딕셔너리에 value의 길이가 5이면 개수 카운트
+            if len(arr) == 5:
+                cnt += 1
+        for arr in col_dict.values():
+            if len(arr) == 5:
+                cnt += 1
+        for arr in x_dict.values():
+            if len(arr) == 5:
+                cnt += 1
+            
+        if cnt >= 3:                        # 선이 3개이면 빙고 외치기
+            answer = min(answer, ((k * 5) + (t+1))) # 가장 먼저 외치기
+
+print(answer)   


### PR DESCRIPTION
🍪 문제
[BOJ] 2578 빙고
https://www.acmicpc.net/problem/2578

🍊 문제 정의
`Input`
첫 5줄은 빙고판에 쓰여진 수가 한 줄에 다섯 개씩 빈 칸을 사이에 두고 주어짐
뒤 5줄은 사회자가 부르는 수가 한 줄에 다섯 개씩 빈 칸을 사이에 두고 주어짐

`Output`
사회자가 몇 번째 수를 부른 후 철수가 "빙고"를 외치게 되는지 출력

🍑 알고리즘 설계
- bingo 리스트의 숫자 인덱스 위치에 빙고판 (i, j) 저장
예시) bingo = [0, (1, 1), (0, 2), (1, 3), (3, 1), (2, 2), (2, 0), (4, 2), (3, 2), (3, 4), (0, 4), (0, 0), (0, 1), (1, 2), (3, 3), (4, 1), (1, 0), (2, 4), (4, 4), (3, 0), (2, 1), (2, 3), (4, 0), (4, 3), (0, 3), (1, 4)]
- row_dic이라는 행 딕셔너리를 만듦. 예를 들어 1번 줄이 가로로 지워진다면 1: [0, 1, 4, 3, 2] 이런식으로 저장됨
- 비슷한 방법으로 열 딕셔너리, 대각선 딕셔너리를 만들고 사회자의 입력 순서대로 딕셔너리에 저장
- 사회자가 번호를 하나씩 부를 때마다 빙고 선의 개수를 계산함
- 딕셔너리에 value의 길이가 5이면 개수를 카운트하는 방식
- 선이 3개가 되면 빙고를 외치고, 가장 먼저 외친 순서만 정답

🍰 특이 사항 (Optional)
X

----

🍪 문제
[BOJ] 20546 기적의 매매법
https://www.acmicpc.net/problem/20546

🍊 문제 정의
`Input`
첫 번째 줄에 준현이와 성민이에게 주어진 현금이 주어진다.
두 번째 줄에 2021년 1월 1일부터 2021년 1월 14일까지의 MachineDuck 주가가 공백을 두고 차례대로 주어진다. 모든 입력은 1000 이하의 양의 정수이다.

`Output`
1월 14일 기준 준현이의 자산이 더 크다면 "BNP"를, 성민이의 자산이 더 크다면 "TIMING"을 출력한다.
둘의 자산이 같다면 "SAMESAME"을 출력한다. 모든 결과 따옴표를 제외하고 출력한다.

🍑 알고리즘 설계
- 입력받은 주가 데이터를 하나씩 확인하면서,
- 준현 전량 매수. (준현 현금 // 주가)로 매수 가능 주식 수 계산
- 주가가 전일 대비 상승했다면 상승횟수를 +1하고 하락횟수를 0으로 초기화
- 주가가 전일 대비 하락했다면 하락횟수를 +1하고 상승횟수를 0으로 초기화
- 주가가 전일 대비 동일하다면 상승횟수와 하락횟수를 0으로 초기화
- 상승횟수가 3이상이라면 성민 전량 매도
- 하락횟수가 3이상이라면 성민 전량 매수. (성민 현금 // 주가)로 매수 가능 주식 수 계산

🍰 특이 사항 (Optional)
X