### PR TITLE
[BOJ] 14501, 14889

### DIFF
--- a/구현-시뮬레이션/14501_현지연.py
+++ b/구현-시뮬레이션/14501_현지연.py
@@ -1,0 +1,58 @@
+# 풀이 1
+# DFS
+n = int(input())    # 전체 상담 개수
+t_list = []         # 각 상담을 완료하는 데 걸리는 기간
+p_list = []         # 각 상담을 완료했을 때 받을 수 있는 금액
+answer = 0
+
+# 데이터 저장
+for _ in range(n):
+    t, p = map(int, input().split())
+    t_list.append(t)
+    p_list.append(p)
+
+def dfs(idx, profit):
+    global answer
+    # N+1일째에는 회사에 없기 때문에, 상담을 할 수 없으므로 종료
+    if idx > n:
+        return
+    # 상담 마지막 날, 이익의 최댓값 저장하고 종료
+    if idx == n:
+        answer = max(answer, profit)
+        return
+    # 상담을 안하는 경우
+    dfs(idx + 1, profit)
+    # 상담을 하는 경우
+    dfs(idx + t_list[idx], profit + p_list[idx])
+
+dfs(0, 0)
+print(answer)
+
+
+# 풀이 2
+# DP
+n = int(input())    # 전체 상담 개수
+t = []              # 각 상담을 완료하는 데 걸리는 기간
+p = []              # 각 상담을 완료했을 때 받을 수 있는 금액
+dp = [0] * (n + 1)  # 다이나믹 프로그래밍을 위한 1차원 dp 테이블 초기화
+                    # i번째 날부터 마지막 날까지 낼 수 있는 최대 이익
+max_value = 0
+
+for _ in range(n):
+    x, y = map(int, input().split())
+    t.append(x)
+    p.append(y)
+
+# 리스트를 뒤에서부터 거꾸로 확인
+for i in range(n - 1, -1, -1):
+    time = t[i] + i # 상담이 끝나는 날짜
+    # 상담이 기간 안에 끝나는 경우
+    if time <= n:
+        # 점화식에 맞게, 현재까지의 최고 이익 계산
+        dp[i] = max(p[i] + dp[time], max_value)
+        max_value = dp[i]
+    # 상담이 기간을 벗어나는 경우
+    else:
+        dp[i] = max_value
+
+print(max_value)

--- a/구현-시뮬레이션/14889_현지연.py
+++ b/구현-시뮬레이션/14889_현지연.py
@@ -1,0 +1,19 @@
+from itertools import combinations
+
+n = int(input())    # 사람 수
+s = [list(map(int, input().split())) for _ in range(n)] # 능력치
+answer = int(1e9)
+
+# 조합을 사용해 모든 경우의 수 계산
+for start_team in list(combinations(range(n), n // 2)):     # 스타트 팀 뽑기
+    link_team = [x for x in range(n) if x not in start_team]    # 스타트 팀이 아닌 사람은 링크 팀
+
+    result = 0  # 두 팀의 능력치 차이
+    for i in range((n // 2) - 1):
+        for j in range(i + 1, n // 2):
+            result += s[start_team[i]][start_team[j]] + s[start_team[j]][start_team[i]]     # 스타트 팀의 능력치는 더하기
+            result -= s[link_team[i]][link_team[j]] + s[link_team[j]][link_team[i]]         # 링크 팀의 능력치는 빼기
+
+    answer = min(answer, abs(result))   # 절댓값을 적용하고 최솟값 저장
+
+print(answer)


### PR DESCRIPTION
🍪 문제
[BOJ] 14501 퇴사
https://www.acmicpc.net/problem/14501

🍊 문제 정의
`Input`
첫째 줄에 N (1 ≤ N ≤ 15)이 주어진다.
둘째 줄부터 N개의 줄에 Ti와 Pi가 공백으로 구분되어서 주어지며, 1일부터 N일까지 순서대로 주어진다. (1 ≤ Ti ≤ 5, 1 ≤ Pi ≤ 1,000)
각각의 상담은 상담을 완료하는데 걸리는 기간 Ti와 상담을 했을 때 받을 수 있는 금액 Pi로 이루어져 있다.

`Output`
백준이가 얻을 수 있는 최대 이익

🍑 알고리즘 설계
풀이1
- T와 P를 각각 리스트로 저장
- DFS로 상담을 안하는 경우와 하는 경우를 둘 다 재귀적으로 함수 호툴
- idx는 인덱스 번호, profit은 현재 이익
- 인덱스 번호가 n 보다 크다면 상담을 할 수 없으므로 그대로 dfs 함수 리턴
- 인덱스 번호가 n이라면 상담의 마지막 날이 끝났으므로 이익의 최댓값을 저장하고 dfs 함수 리턴

풀이2
- T와 P를 각각 리스트로 저장
- 상담 일자를 거꾸로부터 확인하면서
- 현재 상담일자에 상담을 했을 경우 끝나는 날짜를 계산
- 상담이 기간 안에 끝나는 경우
  - DP 테이블에 i번째 날부터 마지막 날까지 낼 수 있는 최대 이익을 저장
  - 현재 최댓값으로 지정
- 상담이 기간 안에 끝나지 않는다면
  - DP 테이블에 이전 최댓값을 저장

🍰 특이 사항 (Optional)
- 풀이2는 책을 참고함

----

🍪 문제
[BOJ] 14889 스타트와 링크
https://www.acmicpc.net/problem/14889

🍊 문제 정의
`Input`
N: 사람의 수 
S_ij :  i번 사람과 j번 사람이 같은 팀에 속했을 때, 팀에 더해지는 능력치

`Output`
스타트 팀과 링크 팀의 능력치의 차이의 최솟값

🍑 알고리즘 설계
- 조합 라이브러리를 이용해 모든 경우의 수 계산
- n//2만큼 사람을 뽑고 스타트 팀 리스트에 저장
- 스타트 팀이 아닌 사람들은 링크 팀 리스트에 저장
- 각 모든 팀원들의 짝을 확인하면서 능력치를 계산
- result 변수에 스타트 팀의 능력치는 더하기
- result 변수에 링크 팀의 능력치는 빼기
- result는 두 팀의 능력치 차이이고, 절댓값을 적용해야 함
- result의 최솟값을 출력