### PR TITLE
[BOJ] 14499 주사위 굴리기

### DIFF
--- a/구현-시뮬레이션/14499_현지연.py
+++ b/구현-시뮬레이션/14499_현지연.py
@@ -1,0 +1,33 @@
+n, m, x, y, k = map(int, input().split())                   # 지도의 크기, 주사위 좌표, 명령의 개수
+graph = [list(map(int, input().split())) for _ in range(n)] # 지도
+move_arr = list(map(int, input().split()))                  # 명령 리스트
+dx = [0, 0, -1, 1]  # 동서북남 이동방향
+dy = [1, -1, 0, 0]
+dice = [0] * 6      # 주사위
+
+for move in move_arr:
+    nx = x + dx[move - 1]   # 명령대로 지도 이동
+    ny = y + dy[move - 1]
+
+    if nx < 0 or n <= nx or ny < 0 or m <= ny:  # 범위를 벗어난 경우 무시
+        continue
+
+    if move == 1:   # 동
+        dice[0], dice[1], dice[2], dice[3] = dice[3], dice[0], dice[1], dice[2]
+    elif move == 2: # 서
+        dice[0], dice[1], dice[2], dice[3] = dice[1], dice[2], dice[3], dice[0]
+    elif move == 3: # 북
+        dice[0], dice[2], dice[4], dice[5] = dice[4], dice[5], dice[2], dice[0]
+    else:           # 남
+        dice[0], dice[2], dice[4], dice[5] = dice[5], dice[4], dice[0], dice[2]
+
+    # 이동한 칸에 쓰여 있는 수가 0이면, 주사위의 바닥면에 쓰여 있는 수가 칸에 복사
+    if graph[nx][ny] == 0:
+        graph[nx][ny] = dice[2]
+    # 0이 아닌 경우에는 칸에 쓰여 있는 수가 주사위의 바닥면으로 복사
+    else:
+        dice[2] = graph[nx][ny]
+        graph[nx][ny] = 0   # 칸에 쓰여 있는 수는 0이 됨
+
+    x, y = nx, ny   # 좌표 업데이트
+    print(dice[0])  # 주사위의 윗 면에 쓰여 있는 수를 출력


### PR DESCRIPTION
🍪 문제
[BOJ] 14499 주사위 굴리기
https://www.acmicpc.net/problem/14499

🍊 문제 정의
`Input`
지도의 세로 크기 N, 가로 크기 M
주사위를 놓은 곳의 좌표 x, y
명령의 개수 K
지도에 쓰여 있는 수
이동하는 명령(동쪽은 1, 서쪽은 2, 북쪽은 3, 남쪽은 4)

`Output`
이동할 때마다 주사위의 윗 면에 쓰여 있는 수를 출력
만약 바깥으로 이동시키려고 하는 경우에는 해당 명령을 무시해야 하며, 출력도 하면 안 됨

🍑 알고리즘 설계
- 동서북남 명령대로 지도의 좌표 이동
- 지도 범위를 벗어난 경우 무시
- 동서북남 명령대로 주사위 굴리기
- 이동한 칸에 쓰여 있는 수가 0이면, 주사위의 바닥면에 쓰여 있는 수가 칸에 복사
- 0이 아닌 경우에는 칸에 쓰여 있는 수가 주사위의 바닥면으로 복사 후, 칸에 쓰여 있는 수는 0이 됨
- 좌표 업데이트
- 주사위의 윗 면에 쓰여 있는 수를 출력

🍰 특이 사항 (Optional)
![image](https://github.com/Pororo-Study/BOJ/assets/55076959/109a7b67-fcc7-41af-9665-3143edd8435d)
