### PR TITLE
[BOJ] 15685 드래곤 커브

### DIFF
--- a/구현-시뮬레이션/15685_현지연.py
+++ b/구현-시뮬레이션/15685_현지연.py
@@ -1,0 +1,38 @@
+# 15685 드래곤 커브
+# https://www.acmicpc.net/problem/15685
+
+n = int(input())
+answer = 0
+
+dx = [0, -1, 0, 1]  # 우상좌하
+dy = [1, 0, -1, 0]
+
+graph = [[0] * 101 for _ in range(101)]
+
+for _ in range(n):
+    y, x, d, g = map(int, input().split())  # y:행, x:열 
+    
+    dragon_direction = [d]  # 방향 리스트
+
+    for j in range(g):  # 세대 수만큼 반복
+        for k in range(2**(j)-1, -1, -1):   # len(dragon_d)-1 == 2**(j)-1
+            dragon_direction.append((dragon_direction[k] + 1) % 4)
+    # print(dragon_direction) # 최종 방향
+
+    graph[x][y] = 1 # 시작점
+    # print(f"({x}, {y})", end=" ")
+
+    for d in dragon_direction:
+        x += dx[d]
+        y += dy[d]
+        graph[x][y] = 1
+        # print(f"({x}, {y})", end=" ")
+    # print()
+
+# 네 꼭짓점이 모두 색칠되어있는 1x1 정사각형의 개수 구하기
+for i in range(100):
+    for j in range(100):
+        if graph[i][j] and graph[i+1][j] and graph[i][j+1] and graph[i+1][j+1]:
+            answer += 1
+
+print(answer)


### PR DESCRIPTION
🍪 문제
[BOJ] 15685 드래곤 커브
https://www.acmicpc.net/problem/15685

🍊 문제 정의
`Input`
첫째 줄에 드래곤 커브의 개수 N
둘째 줄부터 N개의 줄에는 드래곤 커브의 정보(x, y: 시작점, d: 시작 방향, g: 세대)

`Output`
크기가 1×1인 정사각형의 네 꼭짓점이 모두 드래곤 커브의 일부인 것의 개수

🍑 알고리즘 설계
- 네 꼭짓점이 모두 색칠되어있는 1x1 정사각형의 개수를 구하는 문제이다

처음에는 좌표와 방향을 어떻게 한꺼번에 돌리지??라는 고민이 있었다. 결국 구글링을 해서 힌트를 얻었다.
시작점과 끝세대까지의 모든 방향만 알면 모든 좌표를 구할 수 있다!!

방향에도 규칙이 있었다.
- 0으로 시작하는 방향:
  - 0세대: 0
  - 1세대: 0 1
  - 2세대: 0 1 2 1
  - 3세대: 0 1 2 1 2 3 2 1
  - 4세대: 0 1 2 1 2 3 2 1 2 3 0 3 2 3 2 1 
- n 세대의 방향의 개수는 2**n개
- n-1 세대의 방향 리스트 역순에 +1 해서 이어붙이면 n 세대의 방향 리스트가 나온다

- x축은 → 방향, y축은 ↓ 방향이므로 문제에서 x는 열, y는 행을 뜻한다.
- 행열 방향이 헷갈리므로 x,y 입력을 반대로 받아서 x는 → 방향(행), y는 ↓ 방향(열)으로 정의한다.
- 0: 우, 1: 상, 2: 좌, 3:하 방향이다.
- g세대 끝까지 방향을 구하고, 시작점으로부터 방향을 따라가며 graph 좌표를 표시한다.
- 모든 드래곤 커브에 대해 반복한다
- graph를 처음부터 끝까지 확인하며 정답 개수를 구한다.


🍰 특이 사항 (Optional)

X