### PR TITLE
[BOJ] 13460 구슬 탈출 2

### DIFF
--- a/구현-시뮬레이션/13460_현지연.py
+++ b/구현-시뮬레이션/13460_현지연.py
@@ -1,0 +1,72 @@
+# 구슬 탈출 2
+# https://www.acmicpc.net/problem/13460
+
+import sys
+from collections import deque
+
+input = sys.stdin.readline
+
+n, m = map(int, input().split())
+board = [list(input().rstrip()) for _ in range(n)]
+
+dx = [0, 0, -1, 1]
+dy = [-1, 1, 0, 0]
+
+rx, ry, bx, by = 0, 0, 0, 0 # bfs() 함수화를 위한 초기화
+# 구슬의 좌표 구하기
+for i in range(n):
+    for j in range(m):
+        if board[i][j] == "R":
+            rx, ry = i, j
+        elif board[i][j] == "B":
+            bx, by = i, j
+
+q = deque([(rx, ry, bx, by, 1)])    # 큐
+visited = {(rx, ry, bx, by)}        # 방문여부를 집합에 저장
+
+# 구슬 끝까지 움직이기
+def move(x, y, dx, dy):
+    cnt = 0 # 움직인 칸 수
+    while board[x+dx][y+dy] != "#": # 벽이 아닐때까지 이동
+        if board[x+dx][y+dy] == "O":    # 구멍이면 0 반환
+            return 0, 0, 0
+        x += dx
+        y += dy
+        cnt += 1
+    return x, y, cnt
+
+def bfs():
+    while q:
+        rx, ry, bx, by, cnt = q.popleft()
+
+        if cnt > 10:
+            break
+            
+        for i in range(4):
+            nrx, nry, rcnt = move(rx, ry, dx[i], dy[i]) # 빨간 구슬 움직이기
+            nbx, nby, bcnt = move(bx, by, dx[i], dy[i]) # 파란 구슬 움직이기
+
+            # 파란 구슬이 구멍에 들어간 경우 
+            if nbx == 0 and nby == 0:
+                continue
+            
+            # 빨간 구슬이 구멍에 들어간 경우 성공
+            elif nrx == 0 and nry == 0:
+                print(cnt)
+                return
+
+            # 두 구슬이 같은 칸에 있는 경우 많이 움직인 구슬을 한 칸 뒤로 보냄
+            if nrx == nbx and nry == nby:
+                if rcnt > bcnt:
+                    nrx -= dx[i]
+                    nry -= dy[i]
+                else:
+                    nbx -= dx[i]
+                    nby -= dy[i]
+            
+            if (nrx, nry, nbx, nby) not in visited:
+                visited.add((nrx, nry, nbx, nby))
+                q.append((nrx, nry, nbx, nby, cnt + 1))
+    print(-1)   # 실패
+
+bfs()


### PR DESCRIPTION
🍪 문제
[BOJ] 13460 구슬 탈출 2
https://www.acmicpc.net/problem/15685

🍊 문제 정의
`Input`
첫 번째 줄에 보드의 세로, 가로 크기를 의미하는 두 정수 N, M
N개의 줄에 보드의 모양을 나타내는 길이 M의 문자열( '.': 빈 칸, '#': 벽, 'O': 구멍, 'R': 빨간 구슬, 'B': 파란 구슬)

`Output`
최소 몇 번 만에 빨간 구슬을 구멍을 통해 빼낼 수 있는지 출력
10번 이하로 움직여서 빨간 구슬을 구멍을 통해 빼낼 수 없으면 -1을 출력

🍑 알고리즘 설계
이 문제는 DFS보다 **BFS를 사용하는게 더 효율적**이다. 위치에서 구슬을 움직여 구슬이 이동 가능한 위치를 모두 큐에 저장한 뒤, 또 그 위치를 대상으로 너비우선탐색을 단다면 중간중간 불가능한 위치를 파악하여 탐색을 종료한다.
하지만 DFS를 사용한다면 위치에서 될 수 있는 위치까지 탐색하다가 만약 그 위치가 탈출이 불가능하면 다른 위치를 탐색하기 시작하기 때문에 **최소 횟수를 구하는데 적합하지 않다**.

- 빨간 구슬과 파란 구슬을 각각 끝까지 움직인다
- 두 구슬이 같은 칸에 있는 경우 많이 움직인 구슬을 한 칸 뒤로 보낸다
- 파란 구슬이 구멍에 들어간 경우, 실패이므로 큐에 저장하지 않는다
- 빨간 구슬이 구멍에 들어간 경우, 성공이므로 횟수를 출력한다
- 두 구슬이 구멍에 들어가지 않은 경우, 횟수가 10번 이하인 경우에 큐와 방문 여부에 저장한다


🍰 특이 사항 (Optional)
- https://yeon-code.tistory.com/59
- https://hstory0208.tistory.com/entry/Python%ED%8C%8C%EC%9D%B4%EC%8D%AC-%EB%B0%B1%EC%A4%80-13460-%EA%B5%AC%EC%8A%AC-%ED%83%88%EC%B6%9C2