### PR TITLE
[BOJ] 16234 인구 이동

### DIFF
--- a/구현-시뮬레이션/16234_현지연.py
+++ b/구현-시뮬레이션/16234_현지연.py
@@ -1,0 +1,69 @@
+# 인구 이동
+# https://www.acmicpc.net/problem/16234
+
+import sys
+from collections import deque
+input = sys.stdin.readline
+
+# 땅의 크기(N), L, R값을 입력받기
+n, l, r = map(int, input().split())
+
+# 전체 나라의 정보(N x N)를 입력받기
+graph = []
+for _ in range(n):
+    graph.append(list(map(int, input().split())))
+
+dx = [-1, 0, 1, 0]
+dy = [0, -1, 0, 1]
+
+# 특정 위치에서 출발하여 모든 연합을 체크한 뒤에 데이터 갱신
+def process(x, y, index):
+    # (x, y)의 위치와 연결된 나라(연합) 정보를 담는 리스트
+    united = []
+    united.append((x, y))
+    # 너비 우선 탐색(BFS)을 위한 큐 자료구조 정의
+    q = deque()
+    q.append((x, y))
+    union[x][y] = index # 현재 연합의 번호 할당
+    summary = graph[x][y]   # 현재 연합의 전체 인구 수
+    count = 1   # 현재 연합의 국가 수
+    # 큐가 빌 때까지 반복(BFS)
+    while q:
+        x, y = q.popleft()
+        # 현재 위치에서 4가지 방향을 확인하며
+        for i in range(4):
+            nx = x + dx[i]
+            ny = y + dy[i]
+            # 바로 옆에 있는 나라를 확인하여
+            if 0 <= nx < n and 0 <= ny < n and union[nx][ny] == -1:
+                # 옆에 있는 나라와 인구 차이가 L명 이상, R명 이하라면
+                if l <= abs(graph[nx][ny] - graph[x][y]) <= r:
+                    q.append((nx, ny))
+                    # 연합에 추가
+                    union[nx][ny] = index
+                    summary += graph[nx][ny]
+                    count += 1
+                    united.append((nx, ny))
+    # 연합 국가끼리 인구를 분배
+    for i, j in united:
+        graph[i][j] = summary // count
+    return
+
+total_count = 0
+
+# 더 이상 인구 이동을 할 수 없을 때까지 반복
+while True:
+    union = [[-1] * n for _ in range(n)]
+    index = 0
+    for i in range(n):
+        for j in range(n):
+            if union[i][j] == -1:   # 해당 나라가 아직 처리되지 않았다면
+                process(i, j, index)
+                index += 1
+    # 모든 인구 이동이 끝난 경우
+    if index == n * n:
+        break
+    total_count += 1
+
+# 인구 이동 횟수 출력
+print(total_count)


### PR DESCRIPTION
🍪 문제
[BOJ] 16234 인구 이동
https://www.acmicpc.net/problem/16234

🍊 문제 정의
`Input`
첫째 줄에 N, L, R
둘째 줄부터 N개의 줄에 각 나라의 인구수
인구 이동이 발생하는 일수가 2,000번 보다 작거나 같은 입력만 주어짐

`Output`
인구 이동이 며칠 동안 발생하는지 출력

🍑 알고리즘 설계
이 문제는 BFS로 구현을 하는게 좋다.

- united 리스트에 하나의 연합이 되는 나라들의 위치좌표를 담는다
- q 큐를 사용해 BFS로 탐색한다
- union 행렬은 visited 여부를 위해 사용된다
- index는 인구이동을 멈추기 위해 사용한다. 굳이 union 행렬에 저장되지 않아도 됨.

🍰 특이 사항 (Optional)
- https://github.com/jyHyun1014/PythonForCodingTest/blob/main/Problems/21.py
- 이상하게 코드를 비슷하게 작성해도 정답 코드와 동일하지 않으면 시간 초과가 난다.
아무리 GPT를 돌려봐도 잘 모르겠다..