### PR TITLE
[BOJ] 17822 원판 돌리기

### DIFF
--- a/구현-시뮬레이션/17822_현지연.py
+++ b/구현-시뮬레이션/17822_현지연.py
@@ -1,0 +1,85 @@
+# 원판 돌리기
+# https://www.acmicpc.net/problem/17822
+# 시뮬레이션 + BFS
+
+from collections import deque
+
+n, m, t = map(int, input().split())
+
+dx = [0, 1, 0, -1] # 상하좌우 이동
+dy = [1, 0, -1, 0]
+
+graph = [] # 원판 위 숫자 행렬
+
+# 원판 위 숫자 입력받아 저장하기
+for _ in range(n):
+    graph.append(list(map(int, input().split())))
+
+# t번 반복
+for _ in range(t): 
+    x, d, k = map(int, input().split()) # x의 배수인 원판을 d방향으로 k칸 회전
+    
+    # 원판 회전
+    for i in range(n):
+        if (i+1) % x == 0: # 현재 반지름이 i+1인 원판이 x의 배수라면 
+            if d == 0: # 시계방향
+                temp = graph[i][-k:] + graph[i][:-k] # 슬라이싱으로 이어붙이기
+            else: # 반시계방향
+                temp = graph[i][k:] + graph[i][:k]
+            graph[i] = temp
+    
+    total = 0 # 원판에 적힌 수의 합
+    cnt = 0 # 원판에 적힌 수의 개수
+
+    # 인접하면서 같은 수 모두 지우기
+    check = False # 인접하면서 같은 수 존재 여부
+    visited = [[False] * m for _ in range(n)] # 방문 여부
+    for i in range(n):
+        for j in range(m):
+            if not visited[i][j] and graph[i][j] != 0: # 아직 방문하지 않았고 지워진 수가 아니라면
+
+                # 나중에 평균을 구하기 위해 미리 계산
+                total += graph[i][j]
+                cnt += 1
+
+                value = graph[i][j] # 비교할 값
+
+                # BFS
+                q = deque([(i, j)])
+                visited[i][j] = True
+                delete_list = [(i, j)] # 지워야 할 수 위치 목록
+                while q:
+                    now_x, now_y = q.popleft()
+                    for dir in range(4):
+                        next_x = (now_x + dx[dir]) # 1번 원판과 N번 원판은 비교 불가
+                        next_y = (now_y + dy[dir]) % m # 원형으로 비교
+                        if 0<= next_x < n and not visited[next_x][next_y] and graph[next_x][next_y] == value:
+                            q.append((next_x, next_y))
+                            visited[next_x][next_y] = True
+                            delete_list.append((next_x, next_y))
+
+                # 인접하면서 같은 수가 2개 이상이라면 지우기
+                if len(delete_list) >= 2:
+                    check = True
+                    for now_x, now_y in delete_list:
+                        graph[now_x][now_y] = 0
+
+    # 인접하면서 같은 수를 지웠거나, 원판에 남아있는 수가 없다면 넘어가기
+    if check or cnt == 0:
+        continue
+
+    # 원판에 적힌 수의 평균을 구하기
+    avg = total / cnt
+    for i in range(n):
+        for j in range(m):
+            if graph[i][j] != 0 and graph[i][j] > avg: # 평균보다 큰 수는 1 빼기
+                graph[i][j] -= 1
+            elif graph[i][j] != 0 and graph[i][j] < avg: # 평균보다 작은 수는 1 더하기
+                graph[i][j] += 1
+
+# 원판에 적힌 수의 합 구하기
+ans = 0
+for i in range(n):
+    for j in range(m):
+        ans += graph[i][j]
+print(ans)


### PR DESCRIPTION
🍪 문제
[BOJ] 17822 원판 돌리기
https://www.acmicpc.net/problem/17822

🍊 문제 정의
`Input`
첫째 줄에 원판의 개수 N, 하나의 원판 위 정수의 개수 M, 원판을 회전시키는 횟수 T
둘째 줄부터 N개의 줄에 원판에 적힌 수 (i번째 줄의 j번째 수는 (i, j)에 적힌 수를 의미)
다음 T개의 줄에 xi, di, ki (번호가 xi의 배수인 원판을 di방향으로 ki칸 회전)

`Output`
원판을 T번 회전시킨 후 원판에 적힌 수의 합

🍑 알고리즘 설계

1. 원판 회전
  - x로 나눴을 때 나머지가 0인지 비교하여 x의 배수인지 아닌지 판단
  - 슬라이싱으로 리스트를 나눠서 이어붙인다
2. 인접하면서 같은 수 모두 지우기
  - BFS로 큐를 만들어 구현한다
  - 인접한 수는 원 형태로 되어있으므로 `next_y = (now_y + dy[dir]) % m`를 하면 `next_y`가 -1 일때 m-1로, `next_y`가 m일때 0으로 자동으로 바뀐다
  - 이때 나중을 위해서 원판에 적힌 수의 합과 원판에 적힌 수의 개수를 미리 계산한다
  (이중for문을 또 사용하지 않아도 됨. 인접하면서 같은 수가 하나라도 있으면 이 값을 사용할 필요가 없음)
3. 원판에 적힌 수의 평균 구하기
  - 평균보다 큰 수는 1 빼기
  - 평균보다 작은 수는 1 더하기

🍰 특이 사항 (Optional)
- k는 1보다 같거나 크고 M보다 작으므로, 한바퀴 이상 회전하지 않는다
- 인접하고 같은 수가 여러 개 존재한다면 한 번에 **모두** 지운다
- 한번 지워진 수는 다시 사용하지 않는다
- 평균을 구할 때 0으로 나누지 않도록 주의한다 