### PR TITLE
[BOJ] 1018 체스판 다시 칠하기 9079 동전 게임

### DIFF
--- a/완전탐색/1018.py
+++ b/완전탐색/1018.py
@@ -1,0 +1,79 @@
+# 체스판 다시 칠하기
+# https://www.acmicpc.net/problem/1018
+
+# 첫번째 풀이
+n, m = map(int, input().split())
+board = []
+for i in range(n):
+    board.append(list(input()))
+
+w_cnt_board = [[0] * m for _ in range(n)] # 맨 왼쪽 위 칸이 W인 보드 기준, 다시 칠해야 하는 칸
+b_cnt_board = [[0] * m for _ in range(n)] # 맨 왼쪽 위 칸이 B인 보드 기준, 다시 칠해야 하는 칸
+answer = 64
+
+for i in range(n):
+    for j in range(m):
+        if i % 2 == 0:
+            if j % 2 == 0: # 짝짝
+                if board[i][j] == 'B': # W여야하는데 B이면 w_cnt_board를 1로
+                    w_cnt_board[i][j] = 1
+                else:
+                    b_cnt_board[i][j] = 1
+            else: # 짝홀
+                if board[i][j] == 'W':
+                    w_cnt_board[i][j] = 1
+                else:
+                    b_cnt_board[i][j] = 1
+        else:
+            if j % 2 == 0: # 홀짝
+                if board[i][j] == 'W':
+                    w_cnt_board[i][j] = 1
+                else:
+                    b_cnt_board[i][j] = 1
+            else: # 홀홀
+                if board[i][j] == 'B':
+                    w_cnt_board[i][j] = 1
+                else:
+                    b_cnt_board[i][j] = 1
+
+for i in range(n-7):
+    for j in range(m-7):
+        w_cnt = 0 # 맨 왼쪽 위 칸이 W인 보드 기준, 다시 칠해야 하는 정사각형 개수
+        b_cnt = 0 # 맨 왼쪽 위 칸이 B인 보드 기준, 다시 칠해야 하는 정사각형 개수
+        for t in range(8):
+            w_cnt += sum(w_cnt_board[i+t][j:j+8])
+            b_cnt += sum(b_cnt_board[i+t][j:j+8])
+        answer = min(answer, w_cnt, b_cnt)
+
+print(answer)
+
+
+# 두번째 풀이
+# 공간복잡도 효율적
+n, m = map(int, input().split())
+board = [input() for _ in range(n)]
+answer = 64
+
+for i in range(n-7):
+    for j in range(m-7):
+        w_cnt = 0 # 맨 왼쪽 위 칸이 W인 보드 기준, 다시 칠해야 하는 정사각형 개수
+        b_cnt = 0
+
+        for x in range(8):
+            for y in range(8):
+                now = board[i+x][j+y] # 현재 칸
+
+                if (x+y) % 2 == 0: # 짝짝, 홀홀
+                    if now != 'W': # # W여야하는데 B이면 w_cnt에 1 더하기
+                        w_cnt += 1
+                    else:
+                        b_cnt += 1
+                else: # 짝홀, 홀짝
+                    if now != 'B':
+                        w_cnt += 1
+                    else:
+                        b_cnt += 1
+
+        answer = min(answer, w_cnt, b_cnt)
+
+print(answer)

--- a/완전탐색/9079.py
+++ b/완전탐색/9079.py
@@ -1,0 +1,56 @@
+# 동전 게임
+# https://www.acmicpc.net/problem/9079
+
+from collections import deque
+
+ops = [ # 8가지 뒤집기 연산을 비트마스크로 정의
+    0b111000000,  # row0: 첫 번째 행 뒤집기
+    0b000111000,  # row1: 두 번째 행 뒤집기
+    0b000000111,  # row2: 세 번째 행 뒤집기
+    0b100100100,  # col0: 첫 번째 열 뒤집기
+    0b010010010,  # col1: 두 번째 열 뒤집기
+    0b001001001,  # col2: 세 번째 열 뒤집기
+    0b100010001,  # diag ↘ 대각선
+    0b001010100   # diag ↙ 대각선
+]
+
+
+t = int(input()) # 테스트케이스 개수
+
+for _ in range(t):
+
+    initial = 0 # 현재 보드 상태를 9비트 정수로 표현
+    flag = False # # 모든 면이 같아지는 경우 찾았는지 여부
+
+    # 3×3 보드 입력
+    for i in range(3):
+        row = input().split()
+        for j in range(3):
+            if row[j] == "H":
+                # H 이면 해당 위치 비트를 1로 설정
+                initial |= 1 << (i*3 + j) # i*3 + j: 2차원 좌표를 1차원 비트 위치로 변환
+
+    # BFS
+    q = deque([(initial, 0)]) # (state, 뒤집기 횟수)
+    visited = set([initial]) # 방문 여부
+
+    while q:
+        state, cnt = q.popleft() # # 현재 상태와 연산 횟수 꺼내기
+
+        # 목표 상태 확인: 모두 T(0) 또는 모두 H(1) = 511(0b111111111)
+        if state == 0 or state == 511:
+            print(cnt)
+            flag = True # 최소 연산 횟수 출력
+            break
+        
+        # 8가지 연산 적용
+        for op in ops:
+            nxt = state ^ op # XOR: 해당 연산 위치 비트 뒤집기
+
+            if nxt not in visited:
+                visited.add(nxt)
+                q.append((nxt, cnt+1))
+
+    # BFS 끝까지 목표 상태 못 찾으면 -1 출력
+    if not flag:
+        print(-1)


### PR DESCRIPTION
🍪 문제
[BOJ] 1018 체스판 다시 칠하기
https://www.acmicpc.net/problem/1018

🍊 문제 정의
`Input`
- 첫 번째 줄: 보드의 크기 N, M
- 보드의 상태(B는 검은색, W는 흰색)

`Output`
다시 칠해야 하는 정사각형 개수의 최솟값

🍑 알고리즘 설계
- [0][0]이 W라고 했을 때, 짝짝과 홀홀이 W여야하고, 짝홀과 홀짝은 B여야 한다
- [0][0]이 B라고 했을 때, 짝짝과 홀홀이 B여야하고, 짝홀과 홀짝은 W여야 한다

- 첫번째 풀이
  - 다시 칠해야 하는 칸을 미리 계산해둔다
  - 맨 왼쪽 위 칸이 W인 보드 기준, 다시 칠해야 하는 칸을 w_cnt_board에 0, 1로 저장한다
  - 맨 왼쪽 위 칸이 B인 보드 기준, 다시 칠해야 하는 칸을 b_cnt_board에 0, 1로 저장한다
  - [0][0]에서부터 [n-7][m-7]까지를 체스판의 맨왼쪽위칸이라고 간주하고 반복문을 돌린다
  - 위에서 구한 값들을 각각 더한다
  - 최솟값을 비교한다

- 두번째 풀이
  - 그때그때 비교한다
  - (x+y) % 2 == 0은 짝짝, 홀홀
  - (x+y) % 2 == 1은 짝홀, 홀짝을 표현할 수 있다
  - w_cnt_board, b_cnt_board를 사용하지 않아서 공간효율적이다

🍰 특이 사항 (Optional)
- X

------

🍪 문제
[BOJ] 9079 동전 게임
https://www.acmicpc.net/problem/9079

🍊 문제 정의
`Input`
- 테스트 케이스의 개수 T
- 한 줄에 세 개의 동전모양이 주어지는데, 각각의 동전 표시 사이에는 하나의 공백이 주어짐

`Output`
각 테스트 케이스에 대해서, 모두 같은 면이 보이도록 만들기 위한 최소 연산 횟수를 출력하고, 불가능한 경우에는 -1을 출력

🍑 알고리즘 설계
- 8가지 연산이 있다(행 뒤집기 3개, 열 뒤집기 3개, 대각선 뒤집기 2개)
- 한번 실행한 연산은 또 실행할 필요가 없다
- 경우의수를 고른다 8! = 40320
- BFS + 비트마스크로 풀어보자
- 3x3 보드를 입력받을 때 H를 1로하는 9비트 정수로 표현한다 (0 ~ 511)

1 2 3
4 5 6
7 8 9

- BFS의 큐에 (현재 정수, 뒤집기 횟수)를 저장한다
- 현재 정수로 방문 여부를 구분한다
- XOR 연산을 이용해 8가지 비트뒤집기를 한다

🍰 특이 사항 (Optional)
- GPT 답안을 참고함
- 이진수는 숫자맨 앞에 `0b`를 붙인다

| 연산자  | 의미          | 용도                | 
| ---- | ----------- | ----------------- | 
| `&`  | AND         | 특정 비트 확인          | 
| `바`  | OR                | 비트 설정 | 
| `^`  | XOR         | 비트 반전 / 뒤집기       | 
| `~`  | NOT         | 모든 비트 반전          |
| `<<` | Shift left  | 왼쪽으로 비트 이동 (곱하기 2) / 마스크 생성 | 
| `>>` | Shift right | 오른쪽으로 비트 이동 (나누기 2) / 마스크 생성 |
