### PR TITLE
[BOJ] 14501 퇴사

### DIFF
--- a/완전탐색/14501.py
+++ b/완전탐색/14501.py
@@ -1,0 +1,26 @@
+# 퇴사
+# https://www.acmicpc.net/problem/14501
+# DP
+
+n = int(input()) # 전체 상담 개수
+t = [] # 각 상담을 완료하는 데 걸리는 기간
+p = [] # 각 상담을 완료했을 때 받을 수 있는 금액
+dp = [0] * (n+1) # 다이나믹 프로그래밍을 위한 1차원 dp 테이블 초기화
+
+for _ in range(n):
+    a, b = map(int, input().split())
+    t.append(a)
+    p.append(b)
+
+# 리스트를 뒤에서부터 거꾸로 확인
+for i in range(n-1, -1, -1):
+
+    # 상담이 퇴사 전에 끝나는 경우
+    if i + t[i] <= n:
+        dp[i] = max(dp[i+1], dp[i+t[i]] + p[i]) # 상담을 안하거나, 하거나
+
+    # 상담 못하는 경우
+    else:
+        dp[i] = dp[i+1] 
+
+print(dp[0])


### PR DESCRIPTION
🍪 문제
[BOJ] 14501 퇴사
https://www.acmicpc.net/problem/14501

🍊 문제 정의
`Input`
- 전체 상담 개수 N
- 한 줄에 상담을 완료하는데 걸리는 기간, 상담을 했을 때 받을 수 있는 금액 P 사이에 하나의 공백이 주어짐

`Output`
- 백준이가 얻을 수 있는 최대 이익

🍑 알고리즘 설계
- 상담을 한다, 안 한다 2개의 선택지가 있음
- 상담을 하는 경우, `i + t[i]`로 이동, `돈 + p[i]`
- 상담을 안 하는 경우, `i + 1`로 이동, `돈 + 0`
- 즉, i일 → `(i+1)` 또는 `(i+t[i])`
- dp[i] = i일부터 퇴사일까지 얻을 수 있는 최대 돈으로 정의
- 보통 DP는 앞에서부터 계산하지만, 미래 값이 필요하므로 뒤에서부터 계산한다
- 오늘 상담이 퇴사 전에 끝나는 경우, 상담을 안한다면 아무 일도 일어나지 않기 때문에 다음날의 최대 이익을 가져온다
- 오늘 상담이 퇴사 전에 끝나는 경우, 상담을 한다면 상담이 끝나는 날의 다음날의 최대 이익 `dp[i+t[i]]` + 오늘 상담으로 인한 이익 `p[i]`
- 오늘 상담이 퇴사 전에 끝나지 않는 경우, 아무 일도 일어나지 않기 때문에 다음날의 최대 이익을 가져온다 `dp[i] = dp[i+1]`

🍰 특이 사항 (Optional)
- GPT 답안을 참고함
- 이전에 풀었던 문제인데도 이해하기 어려웠음..
- 문제에 나와있는 예제를 직접 손으로 뒤에서부터 풀어보면 이해가 잘 됨