### PR TITLE
[BOJ] 2615 오목

### DIFF
--- a/완전탐색/2615.py
+++ b/완전탐색/2615.py
@@ -1,0 +1,50 @@
+# 오목
+# https://www.acmicpc.net/problem/2615
+
+board = [list(map(int, input().split())) for _ in range(19)]
+
+# 방향: ↗ → ↘ ↓
+dx = [-1, 0, 1, 1]
+dy = [1, 1, 1, 0]
+
+
+for x in range(19):
+    for y in range(19):
+        if board[x][y] == 0:
+            continue
+
+        color = board[x][y] # 색깔 저장
+
+        for d in range(4): # 4 방향
+            cnt = 1
+
+            # 5개 연속 확인
+            for k in range(1, 5): 
+                nx = x + dx[d]*k
+                ny = y + dy[d]*k
+                if 0 <= nx < 19 and 0 <= ny < 19 and board[nx][ny] == color:
+                    cnt += 1
+                else: # 한번이라도 다르면 멈춤
+                    break
+            
+            # 5개면 추가 검사
+            if cnt == 5:
+                # 앞쪽 체크 (6목 방지)
+                px = x - dx[d]
+                py = y - dy[d]
+
+                # 뒤쪽 체크 (6목 방지)
+                nx = x + dx[d]*5
+                ny = y + dy[d]*5
+
+                if 0 <= px < 19 and 0 <= py < 19 and board[px][py] == color:
+                    continue
+                if 0 <= nx < 19 and 0 <= ny < 19 and board[nx][ny] == color:
+                    continue
+                
+                # 정답 출력
+                print(color)
+                print(x+1, y+1)
+                exit()
+
+print(0)


### PR DESCRIPTION
🍪 문제
[BOJ] 2615 오목
https://www.acmicpc.net/problem/2615

🍊 문제 정의
`Input`
- 19줄에 각 줄마다 19개의 숫자로 검은 바둑알은 1, 흰 바둑알은 2, 알이 놓이지 않는 자리는 0

`Output`
- 첫줄에 검은색이 이겼을 경우에는 1을, 흰색이 이겼을 경우에는 2를, 아직 승부가 결정되지 않았을 경우에는 0을 출력
- 둘째 줄에 연속된 다섯 개의 바둑알 중에서 가장 왼쪽에 있는 바둑알(연속된 다섯 개의 바둑알이 세로로 놓인 경우, 그 중 가장 위에 있는 것)의 가로줄 번호와, 세로줄 번호를 순서대로 출력

🍑 알고리즘 설계
- 4 방향만 검사하면 된다 ↗ → ↘ ↓
- 5알 중에서 첫번째 알을 기준으로만 검사하자
- 5개 연속으로 확인한다
- 5개 조건을 만족한다면, 6목을 방지하기 위해 앞쪽과 뒷쪽도 확인한다
- 앞쪽도 확인해야하는 이유는, 1 1 1 1 1 1 일때 첫번째 1에서는 뒷쪽을 확인했기 때문에 6목을 검출해낼 수 있지만 두번째 1을 시작점으로 검사했을때는 6목을 검출할 수 없기 때문이다 또한 두 번째 1을 시작점으로 잘못 판단하는 것을 방지하기 위함이다
- 정답이 출력되는 즉시 프로그램을 종료한다

🍰 특이 사항 (Optional)
- GPT 답안을 참고함
- visited에 x,y 좌표, direction 방향을 저장하는 방법은 너무 복잡함
- 문제 요구 조건이 "시작점" 기준이기때문에 -시작점만 검사하는 방식이 가장 깔끔하다